### PR TITLE
Fix symbol conflicts in dynamic annotations with ThreadSanitizer

### DIFF
--- a/Include/dynamic_annotations.h
+++ b/Include/dynamic_annotations.h
@@ -372,6 +372,24 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/* Note on ThreadSanitizer and dynamic annotations:
+ *
+ * This header uses a dual approach for dynamic annotation functions:
+ * 
+ * 1. When ThreadSanitizer is enabled and Abseil embeded(ABSL_HAVE_THREAD_SANITIZER is defined):
+ *    - Functions (e.g. AnnotateBenignRaceSized) are provided by ThreadSanitizer runtime
+ *    - No declarations needed here as they come from ThreadSanitizer
+ * 
+ * 2. When ThreadSanitizer is disabled:
+ *    - Functions are declared here with unprefixed names
+ *    - This provides API compatibility while having no runtime effect
+ * 
+ * All functions are accessed through _Py_ prefixed macros defined above, allowing:
+ *   - Consistent API usage in CPython code
+ *   - Zero overhead when ThreadSanitizer is disabled
+ *   - Full ThreadSanitizer functionality when enabled
+ */
+#ifndef ABSL_HAVE_THREAD_SANITIZER
 void AnnotateRWLockCreate(const char *file, int line,
                           const volatile void *lock);
 void AnnotateRWLockDestroy(const char *file, int line,
@@ -437,6 +455,7 @@ void AnnotateEnableRaceDetection(const char *file, int line, int enable);
 void AnnotateNoOp(const char *file, int line,
                   const volatile void *arg);
 void AnnotateFlushState(const char *file, int line);
+#endif  /*ABSL_HAVE_THREAD_SANITIZER*/
 
 /* Return non-zero value if running under valgrind.
 

--- a/Include/dynamic_annotations.h
+++ b/Include/dynamic_annotations.h
@@ -372,24 +372,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-/* Note on ThreadSanitizer and dynamic annotations:
- *
- * This header uses a dual approach for dynamic annotation functions:
- * 
- * 1. When ThreadSanitizer is enabled and Abseil embeded(ABSL_HAVE_THREAD_SANITIZER is defined):
- *    - Functions (e.g. AnnotateBenignRaceSized) are provided by ThreadSanitizer runtime
- *    - No declarations needed here as they come from ThreadSanitizer
- * 
- * 2. When ThreadSanitizer is disabled:
- *    - Functions are declared here with unprefixed names
- *    - This provides API compatibility while having no runtime effect
- * 
- * All functions are accessed through _Py_ prefixed macros defined above, allowing:
- *   - Consistent API usage in CPython code
- *   - Zero overhead when ThreadSanitizer is disabled
- *   - Full ThreadSanitizer functionality when enabled
- */
-#ifndef ABSL_HAVE_THREAD_SANITIZER
 void AnnotateRWLockCreate(const char *file, int line,
                           const volatile void *lock);
 void AnnotateRWLockDestroy(const char *file, int line,
@@ -437,10 +419,12 @@ void AnnotateExpectRace(const char *file, int line,
 void AnnotateBenignRace(const char *file, int line,
                         const volatile void *address,
                         const char *description);
+/// proton: starts.
 void AnnotateBenignRaceSized(const char *file, int line,
                         const volatile void *address,
-                        long size,
+                        size_t size,
                         const char *description);
+/// proton: ends.
 void AnnotateMutexIsUsedAsCondVar(const char *file, int line,
                                   const volatile void *mu);
 void AnnotateTraceMemory(const char *file, int line,
@@ -455,7 +439,6 @@ void AnnotateEnableRaceDetection(const char *file, int line, int enable);
 void AnnotateNoOp(const char *file, int line,
                   const volatile void *arg);
 void AnnotateFlushState(const char *file, int line);
-#endif  /*ABSL_HAVE_THREAD_SANITIZER*/
 
 /* Return non-zero value if running under valgrind.
 


### PR DESCRIPTION
When building with ThreadSanitizer enabled alongside other libraries (e.g. Abseil) that implement dynamic annotations, symbol conflicts occur due to duplicate function declarations.

Now we apply a very limited change to make the build/link works.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
